### PR TITLE
Handle hosts-like files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,11 @@ async fn process(tgt: Vec<String>, path: PathBuf) -> Result<()> {
             }
             let line = line.split('#').collect::<Vec<&str>>();
             let line = line.first().unwrap().trim();
+
+            let line = if line.split_whitespace().count() == 2 {
+                // This looks like a "<IP> <Name>" pair; drop the IP
+                line.split_whitespace().nth(1).unwrap_or("")
+            } else {line};
             let line = String::from(line.trim_end_matches('\n'));
             urls.push(line);
         }


### PR DESCRIPTION
What we want is a list of domains to block. Some sources are simple lists of hostnames, but others are of a format suitable for appending to `/etc/hosts`.

This patch looks for lines which have embedded whitespace and only return the section after the whitespace. Thus:
```
0.0.0.0 example.com
```
becomes:
```
example.com
```